### PR TITLE
Fix cart_item radiobutton

### DIFF
--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -19,8 +19,7 @@
         <td><%= cart_item.product.add_tax_tax_out_price %></td>
         <td>
           <%= form_with model:@cart_item_quantity ,  url: public_cart_item_path(cart_item) , method: :patch , local: true do |f| %>
-            <%= cart_item.quantity %>
-            <%= f.select :quantity , *[1..10] %>
+            <%= f.number_field  :quantity ,value: cart_item.quantity %>
             <%= f.submit "変更", class: "btn btn-info" %>
           <% end %>
         </td>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -34,8 +34,8 @@
         </table>
         <div class="payment">
             送料￥<%= @order.postage %></br>
-            商品合計￥<%= @total_price %></br>
-            請求金額￥<%= @total_price + @order.postage  %>
+            商品合計￥<%= @total_price.to_s(:delimited)  %></br>
+            請求金額￥<%= (@total_price + @order.postage).to_s(:delimited)  %>
         </div>
         <%= form_with model: @order, url: public_orders_path, local: true do |f|%>
             <%= f.hidden_field :customer_id %>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -21,7 +21,7 @@
           <tr>
             <td>
               <strong>お届け先</strong></br>
-              <%= f.radio_button :flag, 1 %>
+              <%= f.radio_button :flag, 1, checked: true %>
               ご自身の住所</br>
               <%= @customer.postcode %>
               <%= @customer.residence %></br>


### PR DESCRIPTION
住所の登録がないまま注文に進むことがない様に、デフォルトで1つ住所を指定しておく様にradio_buttonに設定しました。